### PR TITLE
Remove extern statements from error module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-lib
 
-![Generic badge](https://img.shields.io/badge/version-0.1.0-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-0.1.1-<COLOR>.svg)
 
 JSON-RPC client library for the PeachCloud ecosystem.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 //! Basic error handling for the network, OLED and stats JSON-RPC clients.
 
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_http;
-
 use std::error;
 
 pub type BoxError = Box<dyn error::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,3 @@ pub mod error;
 pub mod network_client;
 pub mod oled_client;
 pub mod stats_client;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
Remove unnecessary `extern` statements from the `error.rs` module and bump the version.