### PR TITLE
Rename client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # peach-lib
 
-![Generic badge](https://img.shields.io/badge/version-0.1.2-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-1.0.0-<COLOR>.svg)
 
 JSON-RPC client library for the PeachCloud ecosystem.
+
+### Usage
+
+Define the dependency in your `Cargo.toml` file:
+
+`peach-lib = { git = "https://github.com/peachcloud/peach-lib", branch = "main"  }`
+
+Import the required client from the library:
+
+```rust
+use peach_lib::network_client;
+```
+
+Call one of the exposed methods:
+
+```rust
+network_client::ip()?;
+```
 
 ### Licensing
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,24 +5,6 @@ use std::error;
 pub type BoxError = Box<dyn error::Error>;
 
 #[derive(Debug)]
-pub enum OledError {
-    OledHttp(jsonrpc_client_http::Error),
-    OledClient(jsonrpc_client_core::Error),
-}
-
-impl From<jsonrpc_client_http::Error> for OledError {
-    fn from(err: jsonrpc_client_http::Error) -> OledError {
-        OledError::OledHttp(err)
-    }
-}
-
-impl From<jsonrpc_client_core::Error> for OledError {
-    fn from(err: jsonrpc_client_core::Error) -> OledError {
-        OledError::OledClient(err)
-    }
-}
-
-#[derive(Debug)]
 pub enum NetworkError {
     NetworkHttp(jsonrpc_client_http::Error),
     NetworkClient(jsonrpc_client_core::Error),
@@ -37,6 +19,24 @@ impl From<jsonrpc_client_http::Error> for NetworkError {
 impl From<jsonrpc_client_core::Error> for NetworkError {
     fn from(err: jsonrpc_client_core::Error) -> NetworkError {
         NetworkError::NetworkClient(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum OledError {
+    OledHttp(jsonrpc_client_http::Error),
+    OledClient(jsonrpc_client_core::Error),
+}
+
+impl From<jsonrpc_client_http::Error> for OledError {
+    fn from(err: jsonrpc_client_http::Error) -> OledError {
+        OledError::OledHttp(err)
+    }
+}
+
+impl From<jsonrpc_client_core::Error> for OledError {
+    fn from(err: jsonrpc_client_core::Error) -> OledError {
+        OledError::OledClient(err)
     }
 }
 

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -17,7 +17,7 @@ use crate::stats_client::Traffic;
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `activate_ap` method.
-pub fn network_activate_ap() -> std::result::Result<String, NetworkError> {
+pub fn activate_ap() -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -35,7 +35,7 @@ pub fn network_activate_ap() -> std::result::Result<String, NetworkError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `activate_client` method.
-pub fn network_activate_client() -> std::result::Result<String, NetworkError> {
+pub fn activate_client() -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -58,7 +58,7 @@ pub fn network_activate_client() -> std::result::Result<String, NetworkError> {
 ///
 /// * `ssid` - A string slice containing the SSID of an access point.
 /// * `pass` - A string slice containing the password for an access point.
-pub fn network_add(ssid: &str, pass: &str) -> std::result::Result<String, NetworkError> {
+pub fn add(ssid: &str, pass: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -80,7 +80,7 @@ pub fn network_add(ssid: &str, pass: &str) -> std::result::Result<String, Networ
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_available_networks(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn available_networks(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -104,7 +104,7 @@ pub fn network_available_networks(iface: &str) -> std::result::Result<String, Ne
 ///
 /// * `id` - A string slice containing a network identifier.
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_connect(id: &str, iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn connect(id: &str, iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -127,7 +127,7 @@ pub fn network_connect(id: &str, iface: &str) -> std::result::Result<String, Net
 ///
 /// * `iface` - A string slice containing the network interface identifier.
 /// * `ssid` - A string slice containing the SSID of a network.
-pub fn network_id(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
+pub fn id(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -149,7 +149,7 @@ pub fn network_id(iface: &str, ssid: &str) -> std::result::Result<String, Networ
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_ip(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn ip(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -169,7 +169,7 @@ pub fn network_ip(iface: &str) -> std::result::Result<String, NetworkError> {
 /// `ping` method, which serves as a means of determining availability of the
 /// microservice (ie. there will be no response if `peach-network` is not
 /// running).
-pub fn network_ping() -> std::result::Result<String, NetworkError> {
+pub fn ping() -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -186,7 +186,7 @@ pub fn network_ping() -> std::result::Result<String, NetworkError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `reconfigure` method.
-pub fn network_reconfigure() -> std::result::Result<String, NetworkError> {
+pub fn reconfigure() -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -208,7 +208,7 @@ pub fn network_reconfigure() -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_rssi(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn rssi(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -230,7 +230,7 @@ pub fn network_rssi(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_rssi_percent(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn rssi_percent(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -249,7 +249,7 @@ pub fn network_rssi_percent(iface: &str) -> std::result::Result<String, NetworkE
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `saved_networks` method, which returns a list of networks saved in
 /// `wpa_supplicant.conf`.
-pub fn network_saved_networks() -> std::result::Result<String, NetworkError> {
+pub fn saved_networks() -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -270,7 +270,7 @@ pub fn network_saved_networks() -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_ssid(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn ssid(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -292,7 +292,7 @@ pub fn network_ssid(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_state(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn state(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -314,7 +314,7 @@ pub fn network_state(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_status(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn status(iface: &str) -> std::result::Result<String, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -336,7 +336,7 @@ pub fn network_status(iface: &str) -> std::result::Result<String, NetworkError> 
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn network_traffic(iface: &str) -> std::result::Result<Traffic, NetworkError> {
+pub fn traffic(iface: &str) -> std::result::Result<Traffic, NetworkError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =

--- a/src/oled_client.rs
+++ b/src/oled_client.rs
@@ -15,7 +15,7 @@ use crate::error::OledError;
 /// * `y_coord` - A 32 byte signed int.
 /// * `string` - A String containing the message to be displayed.
 /// * `font_size` - A String containing `6x8`, `6x12`, `8x16` or `12x16`
-pub fn oled_clear() -> std::result::Result<(), OledError> {
+pub fn clear() -> std::result::Result<(), OledError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -31,7 +31,7 @@ pub fn oled_clear() -> std::result::Result<(), OledError> {
     Ok(())
 }
 
-pub fn oled_draw(
+pub fn draw(
     bytes: Vec<u8>,
     width: u32,
     height: u32,
@@ -53,7 +53,7 @@ pub fn oled_draw(
     Ok("success".to_string())
 }
 
-pub fn oled_flush() -> std::result::Result<(), OledError> {
+pub fn flush() -> std::result::Result<(), OledError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -69,7 +69,7 @@ pub fn oled_flush() -> std::result::Result<(), OledError> {
     Ok(())
 }
 
-pub fn oled_ping() -> std::result::Result<(), OledError> {
+pub fn ping() -> std::result::Result<(), OledError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -85,7 +85,7 @@ pub fn oled_ping() -> std::result::Result<(), OledError> {
     Ok(())
 }
 
-pub fn oled_power(power: bool) -> std::result::Result<(), OledError> {
+pub fn power(power: bool) -> std::result::Result<(), OledError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -101,7 +101,7 @@ pub fn oled_power(power: bool) -> std::result::Result<(), OledError> {
     Ok(())
 }
 
-pub fn oled_write(
+pub fn write(
     x_coord: i32,
     y_coord: i32,
     string: &str,


### PR DESCRIPTION
Rename methods in `network_client` and `oled_client` to make them neater. For example, `network_activate_client()` becomes `activate_client()`. This opens the way for idiomatic `use` statements, paths and function calls in code which utilises the `peach-lib` library. For example:

```rust
use peach_lib::network_client;
```

```rust
network_client::activate_client()?;
```

Since this PR represents a breaking change in the API (which now feels quite stable), I've chosen to bump the version to 1.0.0 🎉 