### PR TITLE
Unified error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-lib"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-lib
 
-![Generic badge](https://img.shields.io/badge/version-1.0.2-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-1.1.0-<COLOR>.svg)
 
 JSON-RPC client library for the PeachCloud ecosystem.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,66 +1,26 @@
 //! Basic error handling for the network, OLED and stats JSON-RPC clients.
 
-use std::error;
-
-pub type BoxError = Box<dyn error::Error>;
-
 #[derive(Debug)]
-pub enum NetworkError {
-    NetworkHttp(jsonrpc_client_http::Error),
-    NetworkClient(jsonrpc_client_core::Error),
+pub enum PeachError {
+    JsonRpcHttp(jsonrpc_client_http::Error),
+    JsonRpcCore(jsonrpc_client_core::Error),
+    Serde(serde_json::error::Error),
 }
 
-impl From<jsonrpc_client_http::Error> for NetworkError {
-    fn from(err: jsonrpc_client_http::Error) -> NetworkError {
-        NetworkError::NetworkHttp(err)
+impl From<jsonrpc_client_http::Error> for PeachError {
+    fn from(err: jsonrpc_client_http::Error) -> PeachError {
+        PeachError::JsonRpcHttp(err)
     }
 }
 
-impl From<jsonrpc_client_core::Error> for NetworkError {
-    fn from(err: jsonrpc_client_core::Error) -> NetworkError {
-        NetworkError::NetworkClient(err)
+impl From<jsonrpc_client_core::Error> for PeachError {
+    fn from(err: jsonrpc_client_core::Error) -> PeachError {
+        PeachError::JsonRpcCore(err)
     }
 }
 
-#[derive(Debug)]
-pub enum OledError {
-    OledHttp(jsonrpc_client_http::Error),
-    OledClient(jsonrpc_client_core::Error),
-}
-
-impl From<jsonrpc_client_http::Error> for OledError {
-    fn from(err: jsonrpc_client_http::Error) -> OledError {
-        OledError::OledHttp(err)
-    }
-}
-
-impl From<jsonrpc_client_core::Error> for OledError {
-    fn from(err: jsonrpc_client_core::Error) -> OledError {
-        OledError::OledClient(err)
-    }
-}
-
-#[derive(Debug)]
-pub enum StatsError {
-    StatsHttp(jsonrpc_client_http::Error),
-    StatsClient(jsonrpc_client_core::Error),
-    StatsSerde(serde_json::error::Error),
-}
-
-impl From<jsonrpc_client_http::Error> for StatsError {
-    fn from(err: jsonrpc_client_http::Error) -> StatsError {
-        StatsError::StatsHttp(err)
-    }
-}
-
-impl From<jsonrpc_client_core::Error> for StatsError {
-    fn from(err: jsonrpc_client_core::Error) -> StatsError {
-        StatsError::StatsClient(err)
-    }
-}
-
-impl From<serde_json::error::Error> for StatsError {
-    fn from(err: serde_json::error::Error) -> StatsError {
-        StatsError::StatsSerde(err)
+impl From<serde_json::error::Error> for PeachError {
+    fn from(err: serde_json::error::Error) -> PeachError {
+        PeachError::Serde(err)
     }
 }

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -12,12 +12,12 @@ use jsonrpc_client_core::*;
 use jsonrpc_client_http::HttpTransport;
 use log::{debug, info};
 
-use crate::error::NetworkError;
+use crate::error::PeachError;
 use crate::stats_client::Traffic;
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `activate_ap` method.
-pub fn activate_ap() -> std::result::Result<String, NetworkError> {
+pub fn activate_ap() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -35,7 +35,7 @@ pub fn activate_ap() -> std::result::Result<String, NetworkError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `activate_client` method.
-pub fn activate_client() -> std::result::Result<String, NetworkError> {
+pub fn activate_client() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -58,7 +58,7 @@ pub fn activate_client() -> std::result::Result<String, NetworkError> {
 ///
 /// * `ssid` - A string slice containing the SSID of an access point.
 /// * `pass` - A string slice containing the password for an access point.
-pub fn add(ssid: &str, pass: &str) -> std::result::Result<String, NetworkError> {
+pub fn add(ssid: &str, pass: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -80,7 +80,7 @@ pub fn add(ssid: &str, pass: &str) -> std::result::Result<String, NetworkError> 
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn available_networks(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn available_networks(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -104,7 +104,7 @@ pub fn available_networks(iface: &str) -> std::result::Result<String, NetworkErr
 ///
 /// * `id` - A string slice containing a network identifier.
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn connect(id: &str, iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn connect(id: &str, iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -127,7 +127,7 @@ pub fn connect(id: &str, iface: &str) -> std::result::Result<String, NetworkErro
 ///
 /// * `iface` - A string slice containing the network interface identifier.
 /// * `ssid` - A string slice containing the SSID of a network.
-pub fn id(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> {
+pub fn id(iface: &str, ssid: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -149,7 +149,7 @@ pub fn id(iface: &str, ssid: &str) -> std::result::Result<String, NetworkError> 
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn ip(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn ip(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -169,7 +169,7 @@ pub fn ip(iface: &str) -> std::result::Result<String, NetworkError> {
 /// `ping` method, which serves as a means of determining availability of the
 /// microservice (ie. there will be no response if `peach-network` is not
 /// running).
-pub fn ping() -> std::result::Result<String, NetworkError> {
+pub fn ping() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -186,7 +186,7 @@ pub fn ping() -> std::result::Result<String, NetworkError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `reconfigure` method.
-pub fn reconfigure() -> std::result::Result<String, NetworkError> {
+pub fn reconfigure() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -208,7 +208,7 @@ pub fn reconfigure() -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn rssi(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn rssi(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -230,7 +230,7 @@ pub fn rssi(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn rssi_percent(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn rssi_percent(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -249,7 +249,7 @@ pub fn rssi_percent(iface: &str) -> std::result::Result<String, NetworkError> {
 /// Creates a JSON-RPC client with http transport and calls the `peach-network`
 /// `saved_networks` method, which returns a list of networks saved in
 /// `wpa_supplicant.conf`.
-pub fn saved_networks() -> std::result::Result<String, NetworkError> {
+pub fn saved_networks() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -270,7 +270,7 @@ pub fn saved_networks() -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn ssid(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn ssid(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -292,7 +292,7 @@ pub fn ssid(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn state(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn state(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -314,7 +314,7 @@ pub fn state(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn status(iface: &str) -> std::result::Result<String, NetworkError> {
+pub fn status(iface: &str) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =
@@ -336,7 +336,7 @@ pub fn status(iface: &str) -> std::result::Result<String, NetworkError> {
 /// # Arguments
 ///
 /// * `iface` - A string slice containing the network interface identifier.
-pub fn traffic(iface: &str) -> std::result::Result<Traffic, NetworkError> {
+pub fn traffic(iface: &str) -> std::result::Result<Traffic, PeachError> {
     debug!("Creating HTTP transport for network client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr =

--- a/src/oled_client.rs
+++ b/src/oled_client.rs
@@ -4,7 +4,7 @@ use jsonrpc_client_core::*;
 use jsonrpc_client_http::HttpTransport;
 use log::{debug, info};
 
-use crate::error::OledError;
+use crate::error::PeachError;
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-oled`
 /// `clear`, `flush` and `write` methods.
@@ -15,7 +15,7 @@ use crate::error::OledError;
 /// * `y_coord` - A 32 byte signed int.
 /// * `string` - A String containing the message to be displayed.
 /// * `font_size` - A String containing `6x8`, `6x12`, `8x16` or `12x16`
-pub fn clear() -> std::result::Result<(), OledError> {
+pub fn clear() -> std::result::Result<(), PeachError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -37,7 +37,7 @@ pub fn draw(
     height: u32,
     x_coord: i32,
     y_coord: i32,
-) -> std::result::Result<String, OledError> {
+) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -53,7 +53,7 @@ pub fn draw(
     Ok("success".to_string())
 }
 
-pub fn flush() -> std::result::Result<(), OledError> {
+pub fn flush() -> std::result::Result<(), PeachError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -69,7 +69,7 @@ pub fn flush() -> std::result::Result<(), OledError> {
     Ok(())
 }
 
-pub fn ping() -> std::result::Result<(), OledError> {
+pub fn ping() -> std::result::Result<(), PeachError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -85,7 +85,7 @@ pub fn ping() -> std::result::Result<(), OledError> {
     Ok(())
 }
 
-pub fn power(on: bool) -> std::result::Result<(), OledError> {
+pub fn power(on: bool) -> std::result::Result<(), PeachError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());
@@ -106,7 +106,7 @@ pub fn write(
     y_coord: i32,
     string: &str,
     font_size: &str,
-) -> std::result::Result<String, OledError> {
+) -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for OLED client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_OLED_SERVER").unwrap_or_else(|_| "127.0.0.1:5112".to_string());

--- a/src/stats_client.rs
+++ b/src/stats_client.rs
@@ -13,7 +13,7 @@ use jsonrpc_client_http::HttpTransport;
 use log::{debug, info};
 use serde_derive::{Deserialize, Serialize};
 
-use crate::error::StatsError;
+use crate::error::PeachError;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CpuStat {
@@ -71,7 +71,7 @@ pub struct Uptime {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-stats`
 /// `cpu_stats_percent` method.
-pub fn cpu_stats_percent() -> std::result::Result<CpuStatPercentages, StatsError> {
+pub fn cpu_stats_percent() -> std::result::Result<CpuStatPercentages, PeachError> {
     debug!("Creating HTTP transport for stats client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_STATS_SERVER").unwrap_or_else(|_| "127.0.0.1:5113".to_string());
@@ -89,7 +89,7 @@ pub fn cpu_stats_percent() -> std::result::Result<CpuStatPercentages, StatsError
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-stats`
 /// `disk_usage` method.
-pub fn disk_usage() -> std::result::Result<String, StatsError> {
+pub fn disk_usage() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for stats client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_STATS_SERVER").unwrap_or_else(|_| "127.0.0.1:5113".to_string());
@@ -106,7 +106,7 @@ pub fn disk_usage() -> std::result::Result<String, StatsError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-stats`
 /// `cpu_stats_percent` method.
-pub fn load_average() -> std::result::Result<LoadAverage, StatsError> {
+pub fn load_average() -> std::result::Result<LoadAverage, PeachError> {
     debug!("Creating HTTP transport for stats client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_STATS_SERVER").unwrap_or_else(|_| "127.0.0.1:5113".to_string());
@@ -124,7 +124,7 @@ pub fn load_average() -> std::result::Result<LoadAverage, StatsError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-stats`
 /// `cpu_stats_percent` method.
-pub fn mem_stats() -> std::result::Result<MemStat, StatsError> {
+pub fn mem_stats() -> std::result::Result<MemStat, PeachError> {
     debug!("Creating HTTP transport for stats client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_STATS_SERVER").unwrap_or_else(|_| "127.0.0.1:5113".to_string());
@@ -142,7 +142,7 @@ pub fn mem_stats() -> std::result::Result<MemStat, StatsError> {
 
 /// Creates a JSON-RPC client with http transport and calls the `peach-stats`
 /// `ping` method.
-pub fn ping() -> std::result::Result<String, StatsError> {
+pub fn ping() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for stats client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_STATS_SERVER").unwrap_or_else(|_| "127.0.0.1:5113".to_string());
@@ -160,7 +160,7 @@ pub fn ping() -> std::result::Result<String, StatsError> {
 /// Creates a JSON-RPC client with http transport and calls the `peach-stats`
 /// `uptime` method. If a successful response is returned, the uptime value (in
 /// seconds) is converted to minutes before being returned to the caller.
-pub fn uptime() -> std::result::Result<String, StatsError> {
+pub fn uptime() -> std::result::Result<String, PeachError> {
     debug!("Creating HTTP transport for stats client.");
     let transport = HttpTransport::new().standalone()?;
     let http_addr = env::var("PEACH_STATS_SERVER").unwrap_or_else(|_| "127.0.0.1:5113".to_string());


### PR DESCRIPTION
Folds the previous three error types (`NetworkError`, `OledError` and `StatsError`) into a single error type (`PeachError`) with variants covering the three possible internal error sources (`jsonrpc_client_http::Error`, `jsonrpc_client_core::Error` and `serde_json::error::Error`).

This decreases redundant code and makes it easier to handle errors in upstream applications such as `peach-probe`.