### PR TITLE
Add dyndns_update_ip function

### DIFF
--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -32,19 +32,18 @@ pub struct PeachDynDnsConfig {
     pub dns_server_address: String,
     #[serde(default)]
     pub tsig_key_path: String,
-    #[serde(default)]  // default is false
+    #[serde(default)] // default is false
     pub enabled: bool,
 }
 
 pub fn default_dyndns_config() -> PeachDynDnsConfig {
-    PeachDynDnsConfig{
+    PeachDynDnsConfig {
         domain: "".to_string(),
         dns_server_address: "".to_string(),
         tsig_key_path: "".to_string(),
-        enabled: false
+        enabled: false,
     }
 }
-
 
 // helper functions for serializing and deserializing PeachConfig from disc
 fn save_peach_config(peach_config: PeachConfig) -> Result<PeachConfig, serde_yaml::Error> {
@@ -103,4 +102,3 @@ pub fn set_config_test_value(new_test_value: &str) -> Result<PeachConfig, serde_
     peach_config.test = new_test_value.to_string();
     save_peach_config(peach_config)
 }
-

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -12,19 +12,39 @@ use std::io::Write;
 // main configuration file
 pub const YAML_PATH: &str = "/var/lib/peachcloud/config.yml";
 
+// we make use of Serde default values in order to make PeachCloud
+// robust and keep running even with a not fully complete config.yml
+
 // main type which represents all peachcloud configurations
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PeachConfig {
-    peach_dyndns: PeachDynDnsConfig,
-    test: String,
+    #[serde(default = "default_dyndns_config")]
+    pub peach_dyndns: PeachDynDnsConfig,
+    #[serde(default)]
+    pub test: String,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct PeachDynDnsConfig {
+    #[serde(default)]
     pub domain: String,
+    #[serde(default)]
     pub dns_server_address: String,
+    #[serde(default)]
     pub tsig_key_path: String,
+    #[serde(default)]  // default is false
+    pub enabled: bool,
 }
+
+pub fn default_dyndns_config() -> PeachDynDnsConfig {
+    PeachDynDnsConfig{
+        domain: "".to_string(),
+        dns_server_address: "".to_string(),
+        tsig_key_path: "".to_string(),
+        enabled: false
+    }
+}
+
 
 // helper functions for serializing and deserializing PeachConfig from disc
 fn save_peach_config(peach_config: PeachConfig) -> Result<PeachConfig, serde_yaml::Error> {
@@ -41,7 +61,7 @@ fn save_peach_config(peach_config: PeachConfig) -> Result<PeachConfig, serde_yam
     Ok(peach_config)
 }
 
-fn load_peach_config() -> Result<PeachConfig, serde_yaml::Error> {
+pub fn load_peach_config() -> Result<PeachConfig, serde_yaml::Error> {
     let peach_config_exists = std::path::Path::new(YAML_PATH).exists();
 
     let peach_config: PeachConfig;
@@ -52,6 +72,7 @@ fn load_peach_config() -> Result<PeachConfig, serde_yaml::Error> {
             domain: "test.dyn.peachcloud.org".to_string(),
             dns_server_address: "dynserver.dyn.peachcloud.org".to_string(),
             tsig_key_path: "/var/lib/peachcloud/peach-dyndns/tsig.key".to_string(),
+            enabled: false,
         };
         peach_config = PeachConfig {
             test: "xyz".to_string(),
@@ -82,3 +103,4 @@ pub fn set_config_test_value(new_test_value: &str) -> Result<PeachConfig, serde_
     peach_config.test = new_test_value.to_string();
     save_peach_config(peach_config)
 }
+

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -133,19 +133,25 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
             .arg(dyndns_config.tsig_key_path)
             .arg("-v")
             .stdin(Stdio::piped())
-            .spawn().unwrap();
+            .spawn()
+            .unwrap();
         // pass nsupdate commands via stdin
         // TODO: put actual IP here
-        let ns_commands = format!("
+        let ns_commands = format!(
+            "
         server {NAMESERVER}
         zone {ZONE}
         update delete {DOMAIN} A
         update add {DOMAIN} 30 A 1.1.1.8
-        send", NAMESERVER = "ns.peachcloud.org", ZONE=dyndns_config.domain,
-        DOMAIN=dyndns_config.domain);
+        send",
+            NAMESERVER = "ns.peachcloud.org",
+            ZONE = dyndns_config.domain,
+            DOMAIN = dyndns_config.domain
+        );
         write!(nsupdate_command.stdin.as_ref().unwrap(), "{}", ns_commands).unwrap();
-        let nsupdate_output = nsupdate_command.wait_with_output()
-                 .expect("failed to wait on child");
+        let nsupdate_output = nsupdate_command
+            .wait_with_output()
+            .expect("failed to wait on child");
         // TODO: if successful, write success message to status log
         // if error, write error message to status log
         info!("output: {:?}", nsupdate_output);

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -31,14 +31,14 @@ pub const DYNDNS_LOG_PATH: &str = "/var/lib/peachcloud/peach-dyndns/latest_resul
 pub fn save_dyndns_key(key: &str) {
     // create directory if it doesn't exist
     fs::create_dir_all(PEACH_DYNDNS_CONFIG_PATH)
-        .expect(&format!("Failed to create: {}", PEACH_DYNDNS_CONFIG_PATH));
+        .unwrap_or_else(|_| panic!("Failed to create: {}", PEACH_DYNDNS_CONFIG_PATH));
     // write key text
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
         .open(TSIG_KEY_PATH)
         .expect(&format!("failed to open {}", TSIG_KEY_PATH));
-    writeln!(file, "{}", key).expect(&format!("Couldn't write to file: {}", TSIG_KEY_PATH));
+    writeln!(file, "{}", key).unwrap_or_else(|_| panic!("Couldn't write to file: {}", TSIG_KEY_PATH));
 }
 
 /// Makes a post request to register a new domain with peach-dyns-server

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -37,8 +37,9 @@ pub fn save_dyndns_key(key: &str) {
         .write(true)
         .create(true)
         .open(TSIG_KEY_PATH)
-        .expect(&format!("failed to open {}", TSIG_KEY_PATH));
-    writeln!(file, "{}", key).unwrap_or_else(|_| panic!("Couldn't write to file: {}", TSIG_KEY_PATH));
+        .unwrap_or_else(|_| panic!("failed to open {}", TSIG_KEY_PATH));
+    writeln!(file, "{}", key)
+        .unwrap_or_else(|_| panic!("Couldn't write to file: {}", TSIG_KEY_PATH));
 }
 
 /// Makes a post request to register a new domain with peach-dyns-server

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -111,7 +111,8 @@ fn get_public_ip_address() -> String {
     // TODO: consider other ways to get public IP address
     let output = Command::new("/usr/bin/curl")
         .arg("ifconfig.me")
-        .output().expect("failed to get public IP");
+        .output()
+        .expect("failed to get public IP");
     let command_output = std::str::from_utf8(&output.stdout).expect("Incorrect format");
     command_output.to_string()
 }
@@ -135,6 +136,7 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
         dyndns_config.enabled,
     );
     if !dyndns_config.enabled {
+        info!("dyndns is not enabled, not updating");
         Ok(false)
     } else {
         // call nsupdate passing appropriate configs
@@ -171,7 +173,8 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
             Ok(true)
         } else {
             info!("nsupdate failed, returning error");
-            let err_msg = String::from_utf8(nsupdate_output.stdout).expect("failed to read stdout from nsupdate");
+            let err_msg = String::from_utf8(nsupdate_output.stdout)
+                .expect("failed to read stdout from nsupdate");
             Err(PeachError::NsUpdateError(err_msg))
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub enum PeachError {
     Serde(serde_json::error::Error),
     ParseBoolError(std::str::ParseBoolError),
     SetConfigError(serde_yaml::Error),
+    NsUpdateError(String),
     YamlError(serde_yaml::Error),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub enum PeachError {
     Serde(serde_json::error::Error),
     ParseBoolError(std::str::ParseBoolError),
     SetConfigError(serde_yaml::Error),
+    YamlError(serde_yaml::Error),
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
@@ -23,5 +24,11 @@ impl From<jsonrpc_client_core::Error> for PeachError {
 impl From<serde_json::error::Error> for PeachError {
     fn from(err: serde_json::error::Error) -> PeachError {
         PeachError::Serde(err)
+    }
+}
+
+impl From<serde_yaml::Error> for PeachError {
+    fn from(err: serde_yaml::Error) -> PeachError {
+        PeachError::YamlError(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config_manager;
+pub mod dyndns_client;
 pub mod error;
 pub mod network_client;
 pub mod oled_client;


### PR DESCRIPTION
This PR includes:
- adding default values to Serde deserialization (to make it more robust)
- adding a dyndns_update_ip function, which uses the current Peachcloud configurations, and nsupdate to update the IP address associated with the domain 

We could still consider to implement a more robust way of looking up the public IP address, but I just started with this to test it. This code is working. 