### PR TITLE
peach-lib error handling with snafu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-lib"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 
@@ -16,4 +16,5 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 env_logger = "0.6"
+snafu = "0.6"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-lib
 
-![Generic badge](https://img.shields.io/badge/version-1.2.5-<COLOR>.svg)
+![Generic badge](https://img.shields.io/badge/version-1.2.6-<COLOR>.svg)
 
 JSON-RPC client library for the PeachCloud ecosystem.
 

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -9,6 +9,9 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 
+use crate::error::PeachError;
+use crate::error::*;
+
 // main configuration file
 pub const YAML_PATH: &str = "/var/lib/peachcloud/config.yml";
 
@@ -30,21 +33,20 @@ pub struct PeachConfig {
 }
 
 // helper functions for serializing and deserializing PeachConfig from disc
-fn save_peach_config(peach_config: PeachConfig) -> Result<PeachConfig, serde_yaml::Error> {
+fn save_peach_config(peach_config: PeachConfig) -> Result<PeachConfig, PeachError> {
     let yaml_str = serde_yaml::to_string(&peach_config)?;
 
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
-        .open(YAML_PATH)
-        .unwrap_or_else(|_| panic!("failed to open {}", YAML_PATH));
+        .open(YAML_PATH).context(ReadConfigError{ file: YAML_PATH.to_string() })?;
 
-    writeln!(file, "{}", yaml_str).unwrap_or_else(|_| panic!("failed to write to {}", YAML_PATH));
+    writeln!(file, "{}", yaml_str).context(WriteConfigError{ file: YAML_PATH.to_string()})?;
 
     Ok(peach_config)
 }
 
-pub fn load_peach_config() -> Result<PeachConfig, serde_yaml::Error> {
+pub fn load_peach_config() -> Result<PeachConfig, PeachError> {
     let peach_config_exists = std::path::Path::new(YAML_PATH).exists();
 
     let peach_config: PeachConfig;
@@ -56,13 +58,12 @@ pub fn load_peach_config() -> Result<PeachConfig, serde_yaml::Error> {
             dyn_domain: "".to_string(),
             dyn_dns_server_address: "".to_string(),
             dyn_tsig_key_path: "".to_string(),
-            dyn_enabled: false
+            dyn_enabled: false,
         };
     }
     // otherwise we load peach config from disk
     else {
-        let contents = fs::read_to_string(YAML_PATH)
-            .unwrap_or_else(|_| panic!("failed to read {}", YAML_PATH));
+        let contents = fs::read_to_string(YAML_PATH).context(ReadConfigError{ file: YAML_PATH.to_string() })?;
         peach_config = serde_yaml::from_str(&contents)?;
     }
 
@@ -74,9 +75,9 @@ pub fn set_peach_dyndns_config(
     dyn_domain: &str,
     dyn_dns_server_address: &str,
     dyn_tsig_key_path: &str,
-    dyn_enabled: bool
-) -> Result<PeachConfig, serde_yaml::Error> {
-    let mut peach_config = load_peach_config().unwrap();
+    dyn_enabled: bool,
+) -> Result<PeachConfig, PeachError> {
+    let mut peach_config = load_peach_config()?;
     peach_config.dyn_domain = dyn_domain.to_string();
     peach_config.dyn_dns_server_address = dyn_dns_server_address.to_string();
     peach_config.dyn_tsig_key_path = dyn_tsig_key_path.to_string();
@@ -84,15 +85,14 @@ pub fn set_peach_dyndns_config(
     save_peach_config(peach_config)
 }
 
-
-pub fn set_external_domain(new_external_domain: &str) -> Result<PeachConfig, serde_yaml::Error> {
-    let mut peach_config = load_peach_config().unwrap();
+pub fn set_external_domain(new_external_domain: &str) -> Result<PeachConfig, PeachError> {
+    let mut peach_config = load_peach_config()?;
     peach_config.external_domain = new_external_domain.to_string();
     save_peach_config(peach_config)
 }
 
-pub fn set_dyndns_enabled_value(enabled_value: bool) -> Result<PeachConfig, serde_yaml::Error> {
-    let mut peach_config = load_peach_config().unwrap();
+pub fn set_dyndns_enabled_value(enabled_value: bool) -> Result<PeachConfig, PeachError> {
+    let mut peach_config = load_peach_config()?;
     peach_config.dyn_enabled = enabled_value;
     save_peach_config(peach_config)
 }

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -39,9 +39,14 @@ fn save_peach_config(peach_config: PeachConfig) -> Result<PeachConfig, PeachErro
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
-        .open(YAML_PATH).context(ReadConfigError{ file: YAML_PATH.to_string() })?;
+        .open(YAML_PATH)
+        .context(ReadConfigError {
+            file: YAML_PATH.to_string(),
+        })?;
 
-    writeln!(file, "{}", yaml_str).context(WriteConfigError{ file: YAML_PATH.to_string()})?;
+    writeln!(file, "{}", yaml_str).context(WriteConfigError {
+        file: YAML_PATH.to_string(),
+    })?;
 
     Ok(peach_config)
 }
@@ -63,7 +68,9 @@ pub fn load_peach_config() -> Result<PeachConfig, PeachError> {
     }
     // otherwise we load peach config from disk
     else {
-        let contents = fs::read_to_string(YAML_PATH).context(ReadConfigError{ file: YAML_PATH.to_string() })?;
+        let contents = fs::read_to_string(YAML_PATH).context(ReadConfigError {
+            file: YAML_PATH.to_string(),
+        })?;
         peach_config = serde_yaml::from_str(&contents)?;
     }
 

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -30,13 +30,20 @@ pub const DYNDNS_LOG_PATH: &str = "/var/lib/peachcloud/peach-dyndns/latest_resul
 /// helper function which saves dyndns TSIG key returned by peach-dyndns-server to /var/lib/peachcloud/peach-dyndns/tsig.key
 pub fn save_dyndns_key(key: &str) -> Result<(), PeachError> {
     // create directory if it doesn't exist
-    fs::create_dir_all(PEACH_DYNDNS_CONFIG_PATH).context(SaveTsigKeyError {path: PEACH_DYNDNS_CONFIG_PATH.to_string()})?;
+    fs::create_dir_all(PEACH_DYNDNS_CONFIG_PATH).context(SaveTsigKeyError {
+        path: PEACH_DYNDNS_CONFIG_PATH.to_string(),
+    })?;
     // write key text
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
-        .open(TSIG_KEY_PATH).context(SaveTsigKeyError{path: TSIG_KEY_PATH.to_string()})?;
-    writeln!(file, "{}", key).context(SaveTsigKeyError{path: TSIG_KEY_PATH.to_string()})?;
+        .open(TSIG_KEY_PATH)
+        .context(SaveTsigKeyError {
+            path: TSIG_KEY_PATH.to_string(),
+        })?;
+    writeln!(file, "{}", key).context(SaveTsigKeyError {
+        path: TSIG_KEY_PATH.to_string(),
+    })?;
     Ok(())
 }
 
@@ -70,7 +77,7 @@ pub fn register_domain(domain: &str) -> std::result::Result<String, PeachError> 
                 Err(err) => Err(err),
             }
         }
-        Err(err) => Err(PeachError::JsonRpcClientCore{source: err}),
+        Err(err) => Err(PeachError::JsonRpcClientCore { source: err }),
     }
 }
 
@@ -92,10 +99,10 @@ pub fn is_domain_available(domain: &str) -> std::result::Result<bool, PeachError
             let result: Result<bool, ParseBoolError> = FromStr::from_str(&result_str);
             match result {
                 Ok(result_bool) => Ok(result_bool),
-                Err(err) => Err(PeachError::ParseBoolError{source: err}),
+                Err(err) => Err(PeachError::ParseBoolError { source: err }),
             }
         }
-        Err(err) => Err(PeachError::JsonRpcClientCore{ source: err}),
+        Err(err) => Err(PeachError::JsonRpcClientCore { source: err }),
     }
 }
 
@@ -167,7 +174,7 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
             info!("nsupdate failed, returning error");
             let err_msg = String::from_utf8(nsupdate_output.stdout)
                 .expect("failed to read stdout from nsupdate");
-            Err(PeachError::NsUpdateError{ msg: err_msg})
+            Err(PeachError::NsUpdateError { msg: err_msg })
         }
     }
 }

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -143,9 +143,9 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
             .arg("-k")
             .arg(peach_config.dyn_tsig_key_path)
             .arg("-v")
-            .stdin(Stdio::piped())
-            .spawn()
-            .unwrap();
+            .stdin(Stdio::piped
+                ())
+            .spawn().context(NsCommandError)?;
         // pass nsupdate commands via stdin
         let public_ip_address = get_public_ip_address();
         info!("found public ip address: {}", public_ip_address);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,63 +1,74 @@
 //! Basic error handling for the network, OLED, stats and dyndns JSON-RPC clients.
+pub use snafu::ResultExt;
 use snafu::Snafu;
 use std::error;
-pub use snafu::ResultExt;
 pub type BoxError = Box<dyn error::Error>;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum PeachError {
     #[snafu(display("{}", source))]
-    JsonRpcHttp{ source: jsonrpc_client_http::Error},
+    JsonRpcHttp { source: jsonrpc_client_http::Error },
     #[snafu(display("{}", source))]
-    JsonRpcClientCore{ source: jsonrpc_client_core::Error},
+    JsonRpcClientCore { source: jsonrpc_client_core::Error },
     #[snafu(display("{}", source))]
-    Serde{ source: serde_json::error::Error},
+    Serde { source: serde_json::error::Error },
     #[snafu(display("{}", source))]
-    ParseBoolError{ source: std::str::ParseBoolError},
+    ParseBoolError { source: std::str::ParseBoolError },
     #[snafu(display("{}", source))]
-    SetConfigError{ source: serde_yaml::Error},
+    SetConfigError { source: serde_yaml::Error },
     #[snafu(display("Failed to read: {}", file))]
-    ReadConfigError{ source: std::io::Error, file: String},
+    ReadConfigError {
+        source: std::io::Error,
+        file: String,
+    },
     #[snafu(display("Failed to save: {}", file))]
-    WriteConfigError{ source: std::io::Error, file: String},
+    WriteConfigError {
+        source: std::io::Error,
+        file: String,
+    },
     #[snafu(display("Failed to save tsig key: {} {}", path, source))]
-    SaveTsigKeyError{ source: std::io::Error, path: String},
+    SaveTsigKeyError {
+        source: std::io::Error,
+        path: String,
+    },
     #[snafu(display("{}", msg))]
-    NsUpdateError{ msg: String},
+    NsUpdateError { msg: String },
     #[snafu(display("{}", source))]
-    YamlError{ source: serde_yaml::Error},
+    YamlError { source: serde_yaml::Error },
     #[snafu(display("{:?}", err))]
-    JsonRpcCore{ err: jsonrpc_core::Error },
+    JsonRpcCore { err: jsonrpc_core::Error },
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
     fn from(err: jsonrpc_client_http::Error) -> PeachError {
-        PeachError::JsonRpcHttp{source: err}
+        PeachError::JsonRpcHttp { source: err }
     }
 }
 
 impl From<jsonrpc_client_core::Error> for PeachError {
     fn from(err: jsonrpc_client_core::Error) -> PeachError {
-        PeachError::JsonRpcClientCore{source: err}
+        PeachError::JsonRpcClientCore { source: err }
     }
 }
 
 impl From<serde_json::error::Error> for PeachError {
     fn from(err: serde_json::error::Error) -> PeachError {
-        PeachError::Serde{source: err}
+        PeachError::Serde { source: err }
     }
 }
 
 impl From<serde_yaml::Error> for PeachError {
     fn from(err: serde_yaml::Error) -> PeachError {
-        PeachError::YamlError{source: err}
+        PeachError::YamlError { source: err }
     }
 }
 
 impl From<std::io::Error> for PeachError {
     fn from(err: std::io::Error) -> PeachError {
-        PeachError::ReadConfigError{source: err, file: "".to_string()}
+        PeachError::ReadConfigError {
+            source: err,
+            file: "".to_string(),
+        }
     }
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,12 @@ pub enum PeachError {
     NsUpdateError { msg: String },
     #[snafu(display("Failed to run nsupdate: {}", source))]
     NsCommandError { source: std::io::Error },
+    #[snafu(display("Failed to get public IP address: {}", source))]
+    GetPublicIpError { source: std::io::Error },
+    #[snafu(display("Failed to decode public ip: {}", source))]
+    DecodePublicIpError { source: std::str::Utf8Error },
+    #[snafu(display("Failed to decode nsupdate output: {}", source))]
+    DecodeNsUpdateOutputError { source: std::string::FromUtf8Error },
     #[snafu(display("{}", source))]
     YamlError { source: serde_yaml::Error },
     #[snafu(display("{:?}", err))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,8 @@ pub enum PeachError {
     },
     #[snafu(display("{}", msg))]
     NsUpdateError { msg: String },
+    #[snafu(display("Failed to run nsupdate: {}", source))]
+    NsCommandError { source: std::io::Error },
     #[snafu(display("{}", source))]
     YamlError { source: serde_yaml::Error },
     #[snafu(display("{:?}", err))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,36 +1,63 @@
 //! Basic error handling for the network, OLED, stats and dyndns JSON-RPC clients.
-#[derive(Debug)]
+use snafu::Snafu;
+use std::error;
+pub use snafu::ResultExt;
+pub type BoxError = Box<dyn error::Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 pub enum PeachError {
-    JsonRpcHttp(jsonrpc_client_http::Error),
-    JsonRpcClientCore(jsonrpc_client_core::Error),
-    Serde(serde_json::error::Error),
-    ParseBoolError(std::str::ParseBoolError),
-    SetConfigError(serde_yaml::Error),
-    NsUpdateError(String),
-    YamlError(serde_yaml::Error),
-    JsonRpcCore(jsonrpc_core::Error),
+    #[snafu(display("{}", source))]
+    JsonRpcHttp{ source: jsonrpc_client_http::Error},
+    #[snafu(display("{}", source))]
+    JsonRpcClientCore{ source: jsonrpc_client_core::Error},
+    #[snafu(display("{}", source))]
+    Serde{ source: serde_json::error::Error},
+    #[snafu(display("{}", source))]
+    ParseBoolError{ source: std::str::ParseBoolError},
+    #[snafu(display("{}", source))]
+    SetConfigError{ source: serde_yaml::Error},
+    #[snafu(display("Failed to read: {}", file))]
+    ReadConfigError{ source: std::io::Error, file: String},
+    #[snafu(display("Failed to save: {}", file))]
+    WriteConfigError{ source: std::io::Error, file: String},
+    #[snafu(display("Failed to save tsig key: {} {}", path, source))]
+    SaveTsigKeyError{ source: std::io::Error, path: String},
+    #[snafu(display("{}", msg))]
+    NsUpdateError{ msg: String},
+    #[snafu(display("{}", source))]
+    YamlError{ source: serde_yaml::Error},
+    #[snafu(display("{:?}", err))]
+    JsonRpcCore{ err: jsonrpc_core::Error },
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
     fn from(err: jsonrpc_client_http::Error) -> PeachError {
-        PeachError::JsonRpcHttp(err)
+        PeachError::JsonRpcHttp{source: err}
     }
 }
 
 impl From<jsonrpc_client_core::Error> for PeachError {
     fn from(err: jsonrpc_client_core::Error) -> PeachError {
-        PeachError::JsonRpcClientCore(err)
+        PeachError::JsonRpcClientCore{source: err}
     }
 }
 
 impl From<serde_json::error::Error> for PeachError {
     fn from(err: serde_json::error::Error) -> PeachError {
-        PeachError::Serde(err)
+        PeachError::Serde{source: err}
     }
 }
 
 impl From<serde_yaml::Error> for PeachError {
     fn from(err: serde_yaml::Error) -> PeachError {
-        PeachError::YamlError(err)
+        PeachError::YamlError{source: err}
     }
 }
+
+impl From<std::io::Error> for PeachError {
+    fn from(err: std::io::Error) -> PeachError {
+        PeachError::ReadConfigError{source: err, file: "".to_string()}
+    }
+}
+


### PR DESCRIPTION
@mycognosist this PR could be one to talk about. I'm still not sure best patterns for error handling, although starting to get a better sense. 

In this PR, I went through some of the code I wrote in peach-lib, and tried to replace .unwrap() and .expect() with ?. 

As part of this, I also changed PeachError to be a snafu error in peach-lib. 

This raised a question for me about error handling. Two possibilities came to mind:

A: a different snafu error variant for every error, with error messages defined in error.rs

B: some type of error variants in error.rs which is reused in many places, but where we pass a message as an argument which gives some helpful info about where it came from when we call .context 

or maybe there are more possibilities I didn't think of. For now in this PR I've done something closer to A, with a different error variant for every possible error cause. 

Curious to hear thoughts or patterns you've seen. 

Also, in positive news, the peach-dyndns appears to be working. This link http://littleorchard.dyn.peachcloud.org is a link to my peachcloud device running at my current location in the US, whose DNS is served via our bind9 server and was configured using the peach-web interface. 

Here's a photo of the peachcloud with some lavender flowers picked from the garden here :)

![IMAGE 2021-06-10 14:52:22](https://user-images.githubusercontent.com/1831536/121581079-76adad80-c9fb-11eb-8a23-eee04f3fe9f4.jpg)




