### PR TITLE
Add is_dns_updater_online function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 env_logger = "0.6"
 snafu = "0.6"
-
+regex = "1"
+chrono = "0.4.19"

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -193,13 +193,11 @@ pub fn get_num_seconds_since_successful_dns_update() -> Result<Option<i64>, Peac
         .arg("3")
         .output()?;
     let log_output = String::from_utf8(output.stdout)?;
-    info!("journalctl: {}", log_output);
     let re = Regex::new(r".* peach peach-dyndns-updater.*\[(.*) INFO.*result: Ok\(true\)")?;
     let cap = re.captures(&log_output);
     match cap {
         Some(c) => {
             let time_ran = &c[1];
-            info!("time: {}", time_ran);
             // parse time string into chrono time
             let time_ran_dt = DateTime::parse_from_rfc3339(time_ran).context(ChronoParseError {
                 msg: "Error parsing time from peach-dyndns-updater journalctl log",

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -20,6 +20,8 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
 use std::str::ParseBoolError;
+use regex::Regex;
+use chrono::prelude::*;
 
 /// constants for dyndns configuration
 pub const PEACH_DYNDNS_URL: &str = "http://dynserver.dyn.peachcloud.org";
@@ -163,7 +165,8 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
         );
         write!(nsupdate_command.stdin.as_ref().unwrap(), "{}", ns_commands).unwrap();
         let nsupdate_output = nsupdate_command
-            .wait_with_output().context(NsCommandError)?;
+            .wait_with_output()
+            .context(NsCommandError)?;
         info!("output: {:?}", nsupdate_output);
         // We only return a successful result if nsupdate was successful
         if nsupdate_output.status.success() {
@@ -171,10 +174,65 @@ pub fn dyndns_update_ip() -> Result<bool, PeachError> {
             Ok(true)
         } else {
             info!("nsupdate failed, returning error");
-            let err_msg = String::from_utf8(nsupdate_output.stdout).context(DecodeNsUpdateOutputError)?;
+            let err_msg =
+                String::from_utf8(nsupdate_output.stdout).context(DecodeNsUpdateOutputError)?;
             Err(PeachError::NsUpdateError { msg: err_msg })
         }
     }
+}
+
+/// Helper function to return how many seconds since peach-dyndns-updater successfully ran
+pub fn get_num_seconds_since_successful_dns_update() -> Result<Option<i64>, PeachError> {
+    // use journalctl to get the most recent log from peach-dyndns-updater
+    let output = Command::new("/usr/bin/journalctl")
+            .arg("-u")
+            .arg("peach-dyndns-updater")
+            .arg("-t")
+            .arg("peach-dyndns-updater")
+            .arg("-n")
+            .arg("3")
+            .output()?;
+    let log_output = String::from_utf8(output.stdout)?;
+    info!("journalctl: {}", log_output);
+    let re = Regex::new(r".* peach peach-dyndns-updater.*\[(.*) INFO.*result: Ok\(true\)")?;
+    let cap = re.captures(&log_output);
+    match cap {
+        Some(c) => {
+            let time_ran = &c[1];
+            info!("time: {}", time_ran);
+            // parse time string into chrono time
+            let time_ran_dt = DateTime::parse_from_rfc3339(time_ran)
+               .context(ChronoParseError{ msg: "Error parsing time from peach-dyndns-updater journalctl log"})?;
+            let current_time : DateTime<Utc> = Utc::now();
+            let duration = current_time.signed_duration_since(time_ran_dt);
+            let duration_in_seconds = duration.num_seconds();
+            Ok(Some(duration_in_seconds))
+        }
+        // if the regex doesn't match, then return None
+        None => Ok(None)
+    }
+}
+
+/// helper function which returns a true result if peach-dyndns-updater is enabled
+/// and has successfully run recently (in the last six minutes)
+pub fn is_dns_updater_online() -> Result<bool, PeachError> {
+    // first check if it is enabled in peach-config
+    let peach_config = load_peach_config()?;
+    let is_enabled = peach_config.dyn_enabled;
+    // then check if it has successfully run within the last 6 minutes (60*6 seconds)
+    let num_seconds_since_successful_update = get_num_seconds_since_successful_dns_update()?;
+    let ran_recently: bool;
+    match num_seconds_since_successful_update {
+        Some(seconds) => {
+            ran_recently = seconds < (60*6);
+        }
+        // if the value is None, then the last time it ran successfully is unknown
+        None => {
+            ran_recently = false;
+        }
+    }
+    // if both are true, then return true
+    Ok(is_enabled && ran_recently)
 }
 
 jsonrpc_client!(pub struct PeachDynDnsClient {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,10 @@ pub enum PeachError {
     #[snafu(display("Stdio error: {}", source))]
     StdIoError { source: std::io::Error },
     #[snafu(display("Failed to parse time from {} {}", source, msg))]
-    ChronoParseError { source: chrono::ParseError, msg: String },
+    ChronoParseError {
+        source: chrono::ParseError,
+        msg: String,
+    },
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
@@ -82,7 +85,7 @@ impl From<serde_yaml::Error> for PeachError {
 
 impl From<std::io::Error> for PeachError {
     fn from(err: std::io::Error) -> PeachError {
-        PeachError::StdIoError{ source: err }
+        PeachError::StdIoError { source: err }
     }
 }
 
@@ -100,8 +103,9 @@ impl From<std::string::FromUtf8Error> for PeachError {
 
 impl From<chrono::ParseError> for PeachError {
     fn from(err: chrono::ParseError) -> PeachError {
-        PeachError::ChronoParseError { source: err, msg: "".to_string() }
+        PeachError::ChronoParseError {
+            source: err,
+            msg: "".to_string(),
+        }
     }
 }
-
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,14 @@ pub enum PeachError {
     YamlError { source: serde_yaml::Error },
     #[snafu(display("{:?}", err))]
     JsonRpcCore { err: jsonrpc_core::Error },
+    #[snafu(display("Error creating regex: {}", source))]
+    RegexError { source: regex::Error },
+    #[snafu(display("Failed to decode utf8: {}", source))]
+    FromUtf8Error { source: std::string::FromUtf8Error },
+    #[snafu(display("Stdio error: {}", source))]
+    StdIoError { source: std::io::Error },
+    #[snafu(display("Failed to parse time from {} {}", source, msg))]
+    ChronoParseError { source: chrono::ParseError, msg: String },
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
@@ -74,9 +82,26 @@ impl From<serde_yaml::Error> for PeachError {
 
 impl From<std::io::Error> for PeachError {
     fn from(err: std::io::Error) -> PeachError {
-        PeachError::ReadConfigError {
-            source: err,
-            file: "".to_string(),
-        }
+        PeachError::StdIoError{ source: err }
     }
 }
+
+impl From<regex::Error> for PeachError {
+    fn from(err: regex::Error) -> PeachError {
+        PeachError::RegexError { source: err }
+    }
+}
+
+impl From<std::string::FromUtf8Error> for PeachError {
+    fn from(err: std::string::FromUtf8Error) -> PeachError {
+        PeachError::FromUtf8Error { source: err }
+    }
+}
+
+impl From<chrono::ParseError> for PeachError {
+    fn from(err: chrono::ParseError) -> PeachError {
+        PeachError::ChronoParseError { source: err, msg: "".to_string() }
+    }
+}
+
+


### PR DESCRIPTION
This PR adds an is_dns_updater_online function to dyndns_client.rs, which returns a Result<bool, PeachError>, with the value true if both of the following conditions are true:
1. dyn_enabled is true in peach-config
2. peach-dyndns-updater has successfully run in the past 6 minutes (this is checked using journalctl -u peach-dyndns-updater and using a regex on the latest log messages)

This function could be used by peach-web to display a status message indicating whether or not dyndns is online 

cc @mycognosist 