### PR TITLE
password_utils for setting and resetting passwords 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-lib"
-version = "1.2.12"
+version = "1.2.13"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-lib"
-version = "1.2.11"
+version = "1.2.12"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 
@@ -19,3 +19,4 @@ env_logger = "0.6"
 snafu = "0.6"
 regex = "1"
 chrono = "0.4.19"
+rand="0.8.4"

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -30,6 +30,8 @@ pub struct PeachConfig {
     pub dyn_tsig_key_path: String,
     #[serde(default)] // default is false
     pub dyn_enabled: bool,
+    #[serde(default)] // default is empty vector
+    pub ssb_notify_ids: Vec<String>,
 }
 
 // helper functions for serializing and deserializing PeachConfig from disc
@@ -64,6 +66,7 @@ pub fn load_peach_config() -> Result<PeachConfig, PeachError> {
             dyn_dns_server_address: "".to_string(),
             dyn_tsig_key_path: "".to_string(),
             dyn_enabled: false,
+            ssb_notify_ids: Vec::new(),
         };
     }
     // otherwise we load peach config from disk

--- a/src/dyndns_client.rs
+++ b/src/dyndns_client.rs
@@ -15,11 +15,11 @@ use crate::error::{
     ChronoParseError, DecodeNsUpdateOutputError, DecodePublicIpError, GetPublicIpError,
     NsCommandError, SaveDynDnsResultError, SaveTsigKeyError,
 };
-use regex::Regex;
 use chrono::prelude::*;
 use jsonrpc_client_core::{expand_params, jsonrpc_client};
 use jsonrpc_client_http::HttpTransport;
 use log::{debug, info};
+use regex::Regex;
 use snafu::ResultExt;
 use std::fs;
 use std::fs::OpenOptions;
@@ -63,12 +63,12 @@ pub fn register_domain(domain: &str) -> std::result::Result<String, PeachError> 
     let transport = HttpTransport::new().standalone()?;
     let http_server = PEACH_DYNDNS_URL;
     debug!("Creating HTTP transport handle on {}.", http_server);
-    let transport_handle = transport.handle(&http_server)?;
+    let transport_handle = transport.handle(http_server)?;
     info!("Creating client for peach-dyndns service.");
     let mut client = PeachDynDnsClient::new(transport_handle);
 
     info!("Performing register_domain call to peach-dyndns-server");
-    let res = client.register_domain(&domain).call();
+    let res = client.register_domain(domain).call();
     match res {
         Ok(key) => {
             // save new TSIG key
@@ -94,12 +94,12 @@ pub fn is_domain_available(domain: &str) -> std::result::Result<bool, PeachError
     let transport = HttpTransport::new().standalone()?;
     let http_server = PEACH_DYNDNS_URL;
     debug!("Creating HTTP transport handle on {}.", http_server);
-    let transport_handle = transport.handle(&http_server)?;
+    let transport_handle = transport.handle(http_server)?;
     info!("Creating client for peach_network service.");
     let mut client = PeachDynDnsClient::new(transport_handle);
 
     info!("Performing register_domain call to peach-dyndns-server");
-    let res = client.is_domain_available(&domain).call();
+    let res = client.is_domain_available(domain).call();
     info!("res: {:?}", res);
     match res {
         Ok(result_str) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,8 +50,10 @@ pub enum PeachError {
     RegexError { source: regex::Error },
     #[snafu(display("Failed to decode utf8: {}", source))]
     FromUtf8Error { source: std::string::FromUtf8Error },
-    #[snafu(display("Stdio error: {}", source))]
-    StdIoError { source: std::io::Error },
+    #[snafu(display("Encountered Utf8Error: {}", source))]
+    Utf8Error { source: std::str::Utf8Error },
+    #[snafu(display("Stdio error: {}: {}", msg, source))]
+    StdIoError { source: std::io::Error, msg: String },
     #[snafu(display("Failed to parse time from {} {}", source, msg))]
     ChronoParseError {
         source: chrono::ParseError,
@@ -59,6 +61,12 @@ pub enum PeachError {
     },
     #[snafu(display("Failed to save dynamic dns success log: {}", source))]
     SaveDynDnsResultError { source: std::io::Error },
+    #[snafu(display("New passwords do not match"))]
+    PasswordsDoNotMatch,
+    #[snafu(display("The supplied password was not correct"))]
+    InvalidPassword,
+    #[snafu(display("Error saving new password: {}", msg))]
+    FailedToSetNewPassword { msg : String }
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
@@ -87,7 +95,7 @@ impl From<serde_yaml::Error> for PeachError {
 
 impl From<std::io::Error> for PeachError {
     fn from(err: std::io::Error) -> PeachError {
-        PeachError::StdIoError { source: err }
+        PeachError::StdIoError { source: err, msg: "".to_string() }
     }
 }
 
@@ -100,6 +108,12 @@ impl From<regex::Error> for PeachError {
 impl From<std::string::FromUtf8Error> for PeachError {
     fn from(err: std::string::FromUtf8Error) -> PeachError {
         PeachError::FromUtf8Error { source: err }
+    }
+}
+
+impl From<std::str::Utf8Error> for PeachError {
+    fn from(err: std::str::Utf8Error) -> PeachError {
+        PeachError::Utf8Error { source: err }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,7 @@ pub enum PeachError {
     #[snafu(display("The supplied password was not correct"))]
     InvalidPassword,
     #[snafu(display("Error saving new password: {}", msg))]
-    FailedToSetNewPassword { msg : String }
+    FailedToSetNewPassword { msg: String },
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {
@@ -95,7 +95,10 @@ impl From<serde_yaml::Error> for PeachError {
 
 impl From<std::io::Error> for PeachError {
     fn from(err: std::io::Error) -> PeachError {
-        PeachError::StdIoError { source: err, msg: "".to_string() }
+        PeachError::StdIoError {
+            source: err,
+            msg: "".to_string(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,15 @@
+// this is to ignore a clippy warning that suggests
+// to replace code with the same code that is already there (possibly a bug)
+#![allow(clippy::nonstandard_macro_braces)]
+
 pub mod config_manager;
 pub mod dyndns_client;
 pub mod error;
 pub mod network_client;
 pub mod oled_client;
+pub mod password_utils;
 pub mod sbot_client;
 pub mod stats_client;
-pub mod password_utils;
 
 // re-export error types
 pub use jsonrpc_client_core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod network_client;
 pub mod oled_client;
 pub mod sbot_client;
 pub mod stats_client;
+pub mod password_utils;
 
 // re-export error types
 pub use jsonrpc_client_core;

--- a/src/network_client.rs
+++ b/src/network_client.rs
@@ -9,6 +9,9 @@
 //! Several helper methods are also included here which bundle multiple client
 //! calls to achieve the desired functionality.
 
+// TODO: fix these clippy errors so this allow can be removed
+#![allow(clippy::needless_borrow)]
+
 use std::env;
 
 use jsonrpc_client_core::{expand_params, jsonrpc_client};

--- a/src/password_utils.rs
+++ b/src/password_utils.rs
@@ -1,19 +1,19 @@
-use std::process::Command;
-use snafu::ResultExt;
 use crate::error::PeachError;
 use crate::error::StdIoError;
 use log::info;
-use std::iter;
-use rand::{Rng, thread_rng};
 use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use snafu::ResultExt;
+use std::iter;
+use std::process::Command;
 
 /// filepath where nginx basic auth passwords are stored
 pub const HTPASSWD_FILE: &str = "/var/lib/peachcloud/passwords/htpasswd";
 /// filepath where random temporary password is stored for password resets
-pub const HTPASSWD_TEMPORARY_PASSWORD_FILE: &str = "/var/lib/peachcloud/passwords/temporary_password";
+pub const HTPASSWD_TEMPORARY_PASSWORD_FILE: &str =
+    "/var/lib/peachcloud/passwords/temporary_password";
 /// the username of the user for nginx basic auth
 pub const PEACHCLOUD_AUTH_USER: &str = "admin";
-
 
 /// Returns Ok(()) if the supplied password is correct,
 /// and returns Err if the supplied password is incorrect.
@@ -23,7 +23,10 @@ pub fn verify_password(password: &str) -> Result<(), PeachError> {
         .arg(HTPASSWD_FILE)
         .arg(PEACHCLOUD_AUTH_USER)
         .arg(password)
-        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+        .output()
+        .context(StdIoError {
+            msg: "htpasswd is not installed",
+        })?;
     if output.status.success() {
         Ok(())
     } else {
@@ -50,15 +53,17 @@ pub fn set_new_password(new_password: &str) -> Result<(), PeachError> {
         .arg(HTPASSWD_FILE)
         .arg(PEACHCLOUD_AUTH_USER)
         .arg(new_password)
-        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+        .output()
+        .context(StdIoError {
+            msg: "htpasswd is not installed",
+        })?;
     if output.status.success() {
         Ok(())
     } else {
         let err_output = String::from_utf8(output.stderr)?;
-        Err(PeachError::FailedToSetNewPassword{msg: err_output})
+        Err(PeachError::FailedToSetNewPassword { msg: err_output })
     }
 }
-
 
 /// Uses htpasswd to set a new temporary password for the admin user
 /// which can be used to reset the permanent password
@@ -68,12 +73,15 @@ pub fn set_new_temporary_password(new_password: &str) -> Result<(), PeachError> 
         .arg(HTPASSWD_TEMPORARY_PASSWORD_FILE)
         .arg(PEACHCLOUD_AUTH_USER)
         .arg(new_password)
-        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+        .output()
+        .context(StdIoError {
+            msg: "htpasswd is not installed",
+        })?;
     if output.status.success() {
         Ok(())
     } else {
         let err_output = String::from_utf8(output.stderr)?;
-        Err(PeachError::FailedToSetNewPassword{msg: err_output})
+        Err(PeachError::FailedToSetNewPassword { msg: err_output })
     }
 }
 
@@ -86,7 +94,10 @@ pub fn verify_temporary_password(password: &str) -> Result<(), PeachError> {
         .arg(HTPASSWD_TEMPORARY_PASSWORD_FILE)
         .arg(PEACHCLOUD_AUTH_USER)
         .arg(password)
-        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+        .output()
+        .context(StdIoError {
+            msg: "htpasswd is not installed",
+        })?;
     if output.status.success() {
         Ok(())
     } else {
@@ -94,17 +105,16 @@ pub fn verify_temporary_password(password: &str) -> Result<(), PeachError> {
     }
 }
 
-
 /// generates a temporary password and sends it via ssb dm
 /// to the ssb id configured to be the admin of the peachcloud device
 pub fn send_password_reset() -> Result<(), PeachError> {
     // first generate a new random password of ascii characters
     let mut rng = thread_rng();
     let temporary_password: String = iter::repeat(())
-            .map(|()| rng.sample(Alphanumeric))
-            .map(char::from)
-            .take(10)
-            .collect();
+        .map(|()| rng.sample(Alphanumeric))
+        .map(char::from)
+        .take(10)
+        .collect();
 
     info!("temporary password: {}", temporary_password);
     // then save this string as a new temporary password

--- a/src/password_utils.rs
+++ b/src/password_utils.rs
@@ -1,0 +1,113 @@
+use std::process::Command;
+use snafu::ResultExt;
+use crate::error::PeachError;
+use crate::error::StdIoError;
+use log::info;
+use std::iter;
+use rand::{Rng, thread_rng};
+use rand::distributions::Alphanumeric;
+
+/// filepath where nginx basic auth passwords are stored
+pub const HTPASSWD_FILE: &str = "/var/lib/peachcloud/passwords/htpasswd";
+/// filepath where random temporary password is stored for password resets
+pub const HTPASSWD_TEMPORARY_PASSWORD_FILE: &str = "/var/lib/peachcloud/passwords/temporary_password";
+/// the username of the user for nginx basic auth
+pub const PEACHCLOUD_AUTH_USER: &str = "admin";
+
+
+/// Returns Ok(()) if the supplied password is correct,
+/// and returns Err if the supplied password is incorrect.
+pub fn verify_password(password: &str) -> Result<(), PeachError> {
+    let output = Command::new("/usr/bin/htpasswd")
+        .arg("-vb")
+        .arg(HTPASSWD_FILE)
+        .arg(PEACHCLOUD_AUTH_USER)
+        .arg(password)
+        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(PeachError::InvalidPassword)
+    }
+}
+
+/// Checks if the given passwords are valid, and returns Ok() if they are and
+/// a PeachError otherwise.
+/// Currently this just checks that the passwords are the same,
+/// but could be extended to test if they are strong enough.
+pub fn validate_new_passwords(new_password1: &str, new_password2: &str) -> Result<(), PeachError> {
+    if new_password1 == new_password2 {
+        Ok(())
+    } else {
+        Err(PeachError::PasswordsDoNotMatch)
+    }
+}
+
+/// Uses htpasswd to set a new password for the admin user
+pub fn set_new_password(new_password: &str) -> Result<(), PeachError> {
+    let output = Command::new("/usr/bin/htpasswd")
+        .arg("-cb")
+        .arg(HTPASSWD_FILE)
+        .arg(PEACHCLOUD_AUTH_USER)
+        .arg(new_password)
+        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let err_output = String::from_utf8(output.stderr)?;
+        Err(PeachError::FailedToSetNewPassword{msg: err_output})
+    }
+}
+
+
+/// Uses htpasswd to set a new temporary password for the admin user
+/// which can be used to reset the permanent password
+pub fn set_new_temporary_password(new_password: &str) -> Result<(), PeachError> {
+    let output = Command::new("/usr/bin/htpasswd")
+        .arg("-cb")
+        .arg(HTPASSWD_TEMPORARY_PASSWORD_FILE)
+        .arg(PEACHCLOUD_AUTH_USER)
+        .arg(new_password)
+        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let err_output = String::from_utf8(output.stderr)?;
+        Err(PeachError::FailedToSetNewPassword{msg: err_output})
+    }
+}
+
+/// Returns Ok(()) if the supplied temp_password is correct,
+/// and returns Err if the supplied temp_password is incorrect
+pub fn verify_temporary_password(password: &str) -> Result<(), PeachError> {
+    // TODO: confirm temporary password has not expired
+    let output = Command::new("/usr/bin/htpasswd")
+        .arg("-vb")
+        .arg(HTPASSWD_TEMPORARY_PASSWORD_FILE)
+        .arg(PEACHCLOUD_AUTH_USER)
+        .arg(password)
+        .output().context(StdIoError{ msg: "htpasswd is not installed" })?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(PeachError::InvalidPassword)
+    }
+}
+
+
+/// generates a temporary password and sends it via ssb dm
+/// to the ssb id configured to be the admin of the peachcloud device
+pub fn send_password_reset() -> Result<(), PeachError> {
+    // first generate a new random password of ascii characters
+    let mut rng = thread_rng();
+    let temporary_password: String = iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .map(char::from)
+            .take(10)
+            .collect();
+
+    info!("temporary password: {}", temporary_password);
+    // then save this string as a new temporary password
+    set_new_temporary_password(&temporary_password)?;
+    Ok(())
+}


### PR DESCRIPTION

This PR includes peach-lib functions for setting, verifying and resetting passwords, which are currently used by peach-web.

verify_password
set_new_password
verify_temporary_password
set_new_temporary_password

In the backend this uses apache2-utls, 'htpasswd'.

The main password is stored in '/var/lib/peachcloud/passwords/htpasswd' and the temporary password (used for password resets) is stored in '/var/lib/peachcloud/passwords/temporary_password'

This is working, although there are a few strange UX things about using nginx basic auth, and it might be nice in the future to change this to use a more standard authentication system &mdash; this could also be a good starter project for someone new who wants to contribute to the project. 

cc @mycognosist 