### PR TITLE
Send password reset link via ssb private message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-lib"
-version = "1.2.13"
+version = "1.2.14"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 

--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -101,6 +101,17 @@ pub fn set_external_domain(new_external_domain: &str) -> Result<PeachConfig, Pea
     save_peach_config(peach_config)
 }
 
+pub fn get_peachcloud_domain() -> Result<Option<String>, PeachError> {
+    let peach_config = load_peach_config()?;
+    if !peach_config.external_domain.is_empty() {
+        Ok(Some(peach_config.external_domain))
+    } else if !peach_config.dyn_domain.is_empty() {
+        Ok(Some(peach_config.dyn_domain))
+    } else {
+        Ok(None)
+    }
+}
+
 pub fn set_dyndns_enabled_value(enabled_value: bool) -> Result<PeachConfig, PeachError> {
     let mut peach_config = load_peach_config()?;
     peach_config.dyn_enabled = enabled_value;

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,8 @@ pub enum PeachError {
     InvalidPassword,
     #[snafu(display("Error saving new password: {}", msg))]
     FailedToSetNewPassword { msg: String },
+    #[snafu(display("Error calling sbotcli: {}", msg))]
+    SbotCliError { msg: String },
 }
 
 impl From<jsonrpc_client_http::Error> for PeachError {

--- a/src/sbot_client.rs
+++ b/src/sbot_client.rs
@@ -37,7 +37,7 @@ pub fn post(msg: &str) -> Result<(), PeachError> {
     } else {
         let stderr = std::str::from_utf8(&output.stderr)?;
         Err(PeachError::SbotCliError {
-            msg: format!("Error making ssb post: {}", stderr)
+            msg: format!("Error making ssb post: {}", stderr),
         })
     }
 }
@@ -84,7 +84,7 @@ pub fn update_pub_name(new_name: &str) -> Result<(), PeachError> {
     } else {
         let stderr = std::str::from_utf8(&output.stderr)?;
         Err(PeachError::SbotCliError {
-            msg: format!("Error updating pub name: {}", stderr)
+            msg: format!("Error updating pub name: {}", stderr),
         })
     }
 }
@@ -103,7 +103,7 @@ pub fn private_message(msg: &str, recipient: &str) -> Result<(), PeachError> {
     } else {
         let stderr = std::str::from_utf8(&output.stderr)?;
         Err(PeachError::SbotCliError {
-            msg: format!("Error sending ssb private message: {}", stderr)
+            msg: format!("Error sending ssb private message: {}", stderr),
         })
     }
 }

--- a/src/sbot_client.rs
+++ b/src/sbot_client.rs
@@ -1,7 +1,7 @@
 //! Interfaces for monitoring and configuring go-sbot using sbotcli.
 //!
-//! In the future this could be moved to its own rust repo, but starting here.
 use crate::error::PeachError;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 
 pub fn is_sbot_online() -> Result<bool, PeachError> {
@@ -13,4 +13,97 @@ pub fn is_sbot_online() -> Result<bool, PeachError> {
     // returns true if the service had an exist status of 0 (is running)
     let is_running = status.success();
     Ok(is_running)
+}
+
+/// currently go-sbotcli determines where the working directory is
+/// using the home directory of th user that invokes it
+/// this could be changed to be supplied as CLI arg
+/// but for now all sbotcli commands must first become peach-go-sbot before running
+/// the sudoers file is configured to allow this to happen without a password
+pub fn sbotcli_command() -> Command {
+    let mut command = Command::new("sudo");
+    command
+        .arg("-u")
+        .arg("peach-go-sbot")
+        .arg("/usr/bin/sbotcli");
+    command
+}
+
+pub fn post(msg: &str) -> Result<(), PeachError> {
+    let mut command = sbotcli_command();
+    let output = command.arg("publish").arg("post").arg(msg).output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        Err(PeachError::SbotCliError {
+            msg: format!("Error making ssb post: {}", stderr)
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct WhoAmIValue {
+    id: String,
+}
+
+pub fn whoami() -> Result<String, PeachError> {
+    let mut command = sbotcli_command();
+    let output = command.arg("call").arg("whoami").output()?;
+    let text_output = std::str::from_utf8(&output.stdout)?;
+    let value: WhoAmIValue = serde_json::from_str(text_output)?;
+    let id = value.id;
+    Ok(id)
+}
+
+pub fn create_invite(uses: i32) -> Result<String, PeachError> {
+    let mut command = sbotcli_command();
+    let output = command
+        .arg("invite")
+        .arg("create")
+        .arg("--uses")
+        .arg(uses.to_string())
+        .output()?;
+    let text_output = std::str::from_utf8(&output.stdout)?;
+    let output = text_output.replace("\n", "");
+    Ok(output)
+}
+
+pub fn update_pub_name(new_name: &str) -> Result<(), PeachError> {
+    let pub_ssb_id = whoami()?;
+    let mut command = sbotcli_command();
+    let output = command
+        .arg("publish")
+        .arg("about")
+        .arg("--name")
+        .arg(new_name)
+        .arg(pub_ssb_id)
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        Err(PeachError::SbotCliError {
+            msg: format!("Error updating pub name: {}", stderr)
+        })
+    }
+}
+
+pub fn private_message(msg: &str, recipient: &str) -> Result<(), PeachError> {
+    let mut command = sbotcli_command();
+    let output = command
+        .arg("publish")
+        .arg("post")
+        .arg("--recps")
+        .arg(recipient)
+        .arg(msg)
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = std::str::from_utf8(&output.stderr)?;
+        Err(PeachError::SbotCliError {
+            msg: format!("Error sending ssb private message: {}", stderr)
+        })
+    }
 }


### PR DESCRIPTION
This PR currently hardcodes the recipient admin ID -- the next step will be to add a peach-web page where you can configure the ID of the admin. 

But sending the link via ssb dm works :) Cool to finally be integrating sbot. It seems pretty clean. 

cc @mycognosist 